### PR TITLE
fix(dsh-mobile): 拦截 WebView 渲染进程崩溃，避免 Android 14 闪退

### DIFF
--- a/dsh-mobile/app/src/main/java/com/dshmobile/app/MainActivity.java
+++ b/dsh-mobile/app/src/main/java/com/dshmobile/app/MainActivity.java
@@ -147,6 +147,19 @@ public class MainActivity extends Activity {
                     scheduleReload();
                 }
             }
+
+            @Override
+            public boolean onRenderProcessGone(WebView view,
+                                               android.webkit.RenderProcessGoneDetail detail) {
+                // Android 8+（API 26）渲染进程崩溃时若不在此返回 true，系统会把
+                // 整个 App 进程一起杀掉（"WebView render process gone"）。Android 14
+                // （API 34）的 Pixel/Samsung 等机型加载 dsh UI 时渲染进程偶发闪退
+                // （issue #11），必须拦截并走既有的有界重试，而不是让 App 一起崩掉。
+                // 注意：返回 true 前 view 已失效，不要再调用它。
+                pageFailed = true;
+                scheduleReload();
+                return true;
+            }
         });
         webView.setWebChromeClient(new WebChromeClient() {
             /**


### PR DESCRIPTION
由 opencode agent 自动修复 #11。

Android 8+（API 26）起 WebView 渲染进程崩溃时，若不在 WebViewClient.onRenderProcessGone 返回 true，系统会连带杀掉整个 App 进程。Android 14（API 34）部分机型加载 dsh UI 时渲染进程偶发闪退，此前直接导致 App 崩溃。

修复：拦截 onRenderProcessGone，复用既有的有界重试流程（scheduleReload），渲染进程异常时优雅恢复。

Closes #11